### PR TITLE
Feature/retry and ratelimit

### DIFF
--- a/examples/v2/rateAndRetry/main.go
+++ b/examples/v2/rateAndRetry/main.go
@@ -30,7 +30,7 @@ func main() {
 		bnetSECRET,
 		blizzard.EU,
 		blizzard.EnUS,
-		// This is the client default rate config, we allow 100 requests per second, and a burst of the
+		// This is the client default rate config, we allow 100 requests per second, and a burst budget of 10 requests
 		blizzard.NewRateOpt(1*time.Second/100, 10),
 		// This is the client default retry config
 		blizzard.NewRetryOpt(

--- a/examples/v2/rateAndRetry/main.go
+++ b/examples/v2/rateAndRetry/main.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/FuzzyStatic/blizzard/v2"
-	"github.com/FuzzyStatic/blizzard/v2/wowsearch"
 	"github.com/avast/retry-go"
 )
 
@@ -38,6 +37,7 @@ func main() {
 			retry.Attempts(3),
 			retry.Delay(100*time.Millisecond),
 			retry.DelayType(retry.BackOffDelay),
+			retry.MaxJitter(0),
 			retry.RetryIf(func(err error) bool {
 				switch {
 				case err.Error() == "429 Too Many Requests":
@@ -53,25 +53,14 @@ func main() {
 		),
 	)
 
-	realmSearch, _, err := blizz.ClassicRealmSearch(
-		context.TODO(),
-		wowsearch.Page(1),
-		wowsearch.PageSize(5),
-		wowsearch.OrderBy("name.EN_US:asc"),
-		wowsearch.Field().
-			AND("timezone", "Europe/Paris").
-			AND("data.locale", "enGB").
-			NOT("type.type", "PVP").
-			NOT("id", "4756||4757").
-			OR("type.type", "NORMAL", "RP"),
-	)
+	mount, _, err := blizz.WoWMountIndex(context.TODO())
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	out, err := json.MarshalIndent(realmSearch, "", "  ")
+	out, err := json.MarshalIndent(mount, "", "  ")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	fmt.Println(string(out[:]))

--- a/examples/v2/rateAndRetry/main.go
+++ b/examples/v2/rateAndRetry/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/FuzzyStatic/blizzard/v2"
+	"github.com/FuzzyStatic/blizzard/v2/wowsearch"
+	"github.com/avast/retry-go"
+)
+
+var (
+	bnetID     string
+	bnetSECRET string
+)
+
+func init() {
+	bnetID = os.Getenv("BNET_ID")
+	bnetSECRET = os.Getenv("BNET_SECRET")
+	if bnetID == "" || bnetSECRET == "" {
+		log.Fatal("missing BNET_ID or BNET_SECRET")
+	}
+}
+func main() {
+	blizz := blizzard.NewClient(
+		bnetID,
+		bnetSECRET,
+		blizzard.EU,
+		blizzard.EnUS,
+		// This is the client default rate config, we allow 100 requests per second, and a burst of the
+		blizzard.NewRateOpt(1*time.Second/100, 10),
+		// This is the client default retry config
+		blizzard.NewRetryOpt(
+			retry.Attempts(3),
+			retry.Delay(100*time.Millisecond),
+			retry.DelayType(retry.BackOffDelay),
+			retry.RetryIf(func(err error) bool {
+				switch {
+				case err.Error() == "429 Too Many Requests":
+					return true // recoverable error, retry
+				case err.Error() == "403 Forbidden":
+					return false
+				case err.Error() == "404 Not Found":
+					return false
+				default:
+					return false // We cannot retry this away
+				}
+			}),
+		),
+	)
+
+	realmSearch, _, err := blizz.ClassicRealmSearch(
+		context.TODO(),
+		wowsearch.Page(1),
+		wowsearch.PageSize(5),
+		wowsearch.OrderBy("name.EN_US:asc"),
+		wowsearch.Field().
+			AND("timezone", "Europe/Paris").
+			AND("data.locale", "enGB").
+			NOT("type.type", "PVP").
+			NOT("id", "4756||4757").
+			OR("type.type", "NORMAL", "RP"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	out, err := json.MarshalIndent(realmSearch, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(out[:]))
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/FuzzyStatic/blizzard
 
 go 1.16
 
-require golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+require (
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -9,5 +11,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/v2/blizzard.go
+++ b/v2/blizzard.go
@@ -126,6 +126,7 @@ func NewClient(clientID, clientSecret string, region Region, locale Locale, opts
 			retry.Attempts(3),
 			retry.Delay(100 * time.Millisecond),
 			retry.DelayType(retry.BackOffDelay),
+			retry.MaxJitter(0),
 			retry.RetryIf(func(err error) bool {
 				switch {
 				case err.Error() == "429 Too Many Requests":
@@ -135,7 +136,7 @@ func NewClient(clientID, clientSecret string, region Region, locale Locale, opts
 				case err.Error() == "404 Not Found":
 					return false
 				default:
-					return false // We cannot retry this away
+					return false // unhandled error
 				}
 			}),
 		}

--- a/v2/blizzard_opts.go
+++ b/v2/blizzard_opts.go
@@ -1,0 +1,47 @@
+package blizzard
+
+import (
+	"time"
+
+	"github.com/avast/retry-go"
+	"golang.org/x/time/rate"
+)
+
+// NewRateOpt sets the rate of which the client can do requests
+// Blizzard allows 36000 per hour or up to 100 per second
+//
+// Example:
+//
+//  blizzard.NewRateOpt(1*time.Second/100, 10)
+func NewRateOpt(rate time.Duration, burst int) ClientOpts {
+	return &RateOpt{
+		rate: rate,
+		b:    burst,
+	}
+}
+
+type RateOpt struct {
+	rate time.Duration
+	b    int
+}
+
+func (r *RateOpt) Apply(c *Client) {
+	c.ratelimiter = rate.NewLimiter(
+		rate.Every(r.rate),
+		r.b,
+	)
+}
+
+func NewRetryOpt(opts ...retry.Option) ClientOpts {
+	return &RetryOpt{
+		opts: opts,
+	}
+}
+
+type RetryOpt struct {
+	opts []retry.Option
+}
+
+func (r *RetryOpt) Apply(c *Client) {
+	c.retryopts = r.opts
+}


### PR DESCRIPTION
Adds retry logic in case of 429 as well as ratelimit with sane defaults for the Battle.net API configurable via optional opts on the client to not break backwards compatibility

usage example to configure custom, shown with default values:

also I snuck in a http.Client config with keep-alive, should increase performance for people who use it in backends and system service doing a lot of lookups in a row

```golang
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"log"
	"os"
	"time"

	"github.com/FuzzyStatic/blizzard/v2"
	"github.com/avast/retry-go"
)

var (
	bnetID     string
	bnetSECRET string
)

func init() {
	bnetID = os.Getenv("BNET_ID")
	bnetSECRET = os.Getenv("BNET_SECRET")
	if bnetID == "" || bnetSECRET == "" {
		log.Fatal("missing BNET_ID or BNET_SECRET")
	}
}
func main() {
	blizz := blizzard.NewClient(
		bnetID,
		bnetSECRET,
		blizzard.EU,
		blizzard.EnUS,
		// This is the client default rate config, we allow 100 requests per second, and a burst of the
		blizzard.NewRateOpt(1*time.Second/100, 10),
		// This is the client default retry config
		blizzard.NewRetryOpt(
			retry.Attempts(3),
			retry.Delay(100*time.Millisecond),
			retry.DelayType(retry.BackOffDelay),
			retry.MaxJitter(0),
			retry.RetryIf(func(err error) bool {
				switch {
				case err.Error() == "429 Too Many Requests":
					return true // recoverable error, retry
				case err.Error() == "403 Forbidden":
					return false
				case err.Error() == "404 Not Found":
					return false
				default:
					return false // We cannot retry this away
				}
			}),
		),
	)

	mount, _, err := blizz.WoWMountIndex(context.TODO())
	if err != nil {
		log.Fatal(err)
	}

	out, err := json.MarshalIndent(mount, "", "  ")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(string(out[:]))
}
```