### PR TITLE
Add Get/SetHTTPClient to allow overriding the http.Client used for requests

### DIFF
--- a/examples/v2/timeout/main.go
+++ b/examples/v2/timeout/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/FuzzyStatic/blizzard/v2"
+)
+
+var (
+	clientID     string
+	clientSecret string
+	blizz        *blizzard.Client
+)
+
+func init() {
+	clientID = os.Getenv("CLIENT_ID")
+	if clientID == "" {
+		log.Fatal("Set the environment variable CLIENT_ID before retrying.")
+	}
+
+	clientSecret = os.Getenv("CLIENT_SECRET")
+	if clientSecret == "" {
+		log.Fatal("Set the environment variable CLIENT_SECRET before retrying.")
+	}
+}
+
+func main() {
+	blizz = blizzard.NewClient(
+		clientID,
+		clientSecret,
+		blizzard.US,
+		blizzard.EnUS,
+	)
+
+	blizz.SetHTTPClient(clientWithTimeout(blizz.GetHTTPClient()))
+
+	err := blizz.AccessTokenRequest(context.Background())
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func clientWithTimeout(c *http.Client) *http.Client {
+	c.Timeout = 10 * time.Second
+	return c
+}

--- a/v2/blizzard.go
+++ b/v2/blizzard.go
@@ -184,6 +184,16 @@ func (c *Client) GetStaticClassicNamespace() string {
 	return c.staticClassicNamespace
 }
 
+// GetHTTPClient returns the http.Client used for making requests
+func (c *Client) GetHTTPClient() *http.Client {
+	return c.httpClient
+}
+
+// SetHTTPClient sets the http.Client used for making requests
+func (c *Client) SetHTTPClient(h *http.Client) {
+	c.httpClient = h
+}
+
 // buildSearchParams builds params for searches
 func buildSearchParams(opts ...wowsearch.Opt) string {
 	if len(opts) == 0 {

--- a/v2/blizzard.go
+++ b/v2/blizzard.go
@@ -189,7 +189,10 @@ func (c *Client) GetHTTPClient() *http.Client {
 	return c.httpClient
 }
 
-// SetHTTPClient sets the http.Client used for making requests
+// SetHTTPClient sets the http.Client used for making requests.
+// Calling `SetRegion` will overwrite this client.
+// It is recommended to wrap the client returned by `GetHTTPClient` because
+// the default one handles the oauth flow (see `golang.org/x/oauth2.NewClient`).
 func (c *Client) SetHTTPClient(h *http.Client) {
 	c.httpClient = h
 }


### PR DESCRIPTION
This is useful for adding timeouts (see included example), rate limiting, or caching at the transport layer.