### PR TITLE
Classic wow auction house api

### DIFF
--- a/wowcgd.go
+++ b/wowcgd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/FuzzyStatic/blizzard/v3/wowsearch"
 )
 
-// https://eu.api.blizzard.com/data/wow/connected-realm/4477/auctions/\?namespace\=dynamic-classic-eu
+// ClassicWoWAuctionHouseIndex returns an index of auction houses for a given realmID
 func (c *Client) ClassicWoWAuctionHouseIndex(ctx context.Context, connectedRealmID int) (*wowcgd.AuctionHouseIndex, *Header, error) {
 	dat, header, err := c.getStructData(ctx,
 		fmt.Sprintf("/data/wow/connected-realm/%d/auctions/index", connectedRealmID),
@@ -17,6 +17,16 @@ func (c *Client) ClassicWoWAuctionHouseIndex(ctx context.Context, connectedRealm
 		&wowcgd.AuctionHouseIndex{},
 	)
 	return dat.(*wowcgd.AuctionHouseIndex), header, err
+}
+
+// ClassicWoWAuctions returns all auctions by realmID and auctionHouseID
+func (c *Client) ClassicWoWAuctions(ctx context.Context, connectedRealmID, auctionHouseID int) (*wowcgd.Auctions, *Header, error) {
+	dat, header, err := c.getStructData(ctx,
+		fmt.Sprintf("/data/wow/connected-realm/%d/auctions/%d", connectedRealmID, auctionHouseID),
+		c.GetDynamicClassicNamespace(),
+		&wowcgd.Auctions{},
+	)
+	return dat.(*wowcgd.Auctions), header, err
 }
 
 // ClassicWoWConnectedRealmsIndex returns an index of connected realms.

--- a/wowcgd.go
+++ b/wowcgd.go
@@ -9,6 +9,16 @@ import (
 	"github.com/FuzzyStatic/blizzard/v3/wowsearch"
 )
 
+// https://eu.api.blizzard.com/data/wow/connected-realm/4477/auctions/\?namespace\=dynamic-classic-eu
+func (c *Client) ClassicWoWAuctionHouseIndex(ctx context.Context, connectedRealmID int) (*wowcgd.AuctionHouseIndex, *Header, error) {
+	dat, header, err := c.getStructData(ctx,
+		fmt.Sprintf("/data/wow/connected-realm/%d/auctions/index", connectedRealmID),
+		c.GetDynamicClassicNamespace(),
+		&wowcgd.AuctionHouseIndex{},
+	)
+	return dat.(*wowcgd.AuctionHouseIndex), header, err
+}
+
 // ClassicWoWConnectedRealmsIndex returns an index of connected realms.
 func (c *Client) ClassicWoWConnectedRealmsIndex(ctx context.Context) (*wowcgd.ConnectedRealmsIndex, *Header, error) {
 	dat, header, err := c.getStructData(ctx,

--- a/wowcgd/auctionHouse.go
+++ b/wowcgd/auctionHouse.go
@@ -1,5 +1,6 @@
 package wowcgd
 
+// AuctionHouseIndex structure
 type AuctionHouseIndex struct {
 	Links struct {
 		Self struct {
@@ -15,6 +16,7 @@ type AuctionHouseIndex struct {
 	} `json:"auctions"`
 }
 
+// Auctions structure
 type Auctions struct {
 	Linkds struct {
 		Self struct {
@@ -29,6 +31,7 @@ type Auctions struct {
 	Name     string    `json:"name"`
 }
 
+// Auction structure
 type Auction struct {
 	ID   int `json:"id"`
 	Item struct {

--- a/wowcgd/auctionHouse.go
+++ b/wowcgd/auctionHouse.go
@@ -1,0 +1,29 @@
+package wowcgd
+
+type AuctionHouseIndex struct {
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+	} `json:"_links"`
+	Auctions []struct {
+		Key struct {
+			Href string `json:"href"`
+		} `json:"key"`
+		Name struct {
+			EnUS string `json:"en_US"`
+			EsMX string `json:"es_MX"`
+			PtBR string `json:"pt_BR"`
+			DeDE string `json:"de_DE"`
+			EnGB string `json:"en_GB"`
+			EsES string `json:"es_ES"`
+			FrFR string `json:"fr_FR"`
+			ItIT string `json:"it_IT"`
+			RuRU string `json:"ru_RU"`
+			KoKR string `json:"ko_KR"`
+			ZhTW string `json:"zh_TW"`
+			ZhCN string `json:"zh_CN"`
+		} `json:"name"`
+		ID int `json:"id"`
+	} `json:"auctions"`
+}

--- a/wowcgd/auctionHouse.go
+++ b/wowcgd/auctionHouse.go
@@ -10,20 +10,32 @@ type AuctionHouseIndex struct {
 		Key struct {
 			Href string `json:"href"`
 		} `json:"key"`
-		Name struct {
-			EnUS string `json:"en_US"`
-			EsMX string `json:"es_MX"`
-			PtBR string `json:"pt_BR"`
-			DeDE string `json:"de_DE"`
-			EnGB string `json:"en_GB"`
-			EsES string `json:"es_ES"`
-			FrFR string `json:"fr_FR"`
-			ItIT string `json:"it_IT"`
-			RuRU string `json:"ru_RU"`
-			KoKR string `json:"ko_KR"`
-			ZhTW string `json:"zh_TW"`
-			ZhCN string `json:"zh_CN"`
-		} `json:"name"`
-		ID int `json:"id"`
+		Name string `json:"name"`
+		ID   int    `json:"id"`
 	} `json:"auctions"`
+}
+
+type Auctions struct {
+	Linkds struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+	} `json:"_links"`
+	ConnectedRealm struct {
+		Href string `json:"href"`
+	} `json:"connected_realm"`
+	Auctions []Auction `json:"auctions"`
+	ID       int       `json:"id"`
+	Name     string    `json:"name"`
+}
+
+type Auction struct {
+	ID   int `json:"id"`
+	Item struct {
+		ID int `json:"id"`
+	} `json:"item"`
+	Bid      int    `json:"bid"`
+	Buyout   int    `json:"buyout"`
+	Quantity int    `json:"quantity"`
+	TimeLeft string `json:"time_left"`
 }


### PR DESCRIPTION
The blizzard game data API offers two endpoints to retrieve data related to auction houses and auctions. I noticed that it was missing in this library and added it. 