### PR TITLE
fix(oauth): update oauth endpoints

### DIFF
--- a/blizzard.go
+++ b/blizzard.go
@@ -170,7 +170,7 @@ func (c *Client) SetRegionParameters(region Region, locale Locale) error {
 
 	switch region {
 	case CN:
-		c.oauthHost = "https://www.battlenet.com.cn"
+		c.oauthHost = "https://oauth.battlenet.com.cn"
 		c.apiHost = "https://gateway.battlenet.com.cn"
 		c.dynamicNamespace = "dynamic-zh"
 		c.dynamicClassicNamespace = "dynamic-classic-zh"
@@ -178,7 +178,7 @@ func (c *Client) SetRegionParameters(region Region, locale Locale) error {
 		c.staticNamespace = "static-zh"
 		c.staticClassicNamespace = "static-classic-zh"
 	default:
-		c.oauthHost = fmt.Sprintf("https://%s.battle.net", region)
+		c.oauthHost = "https://oauth.battle.net"
 		c.apiHost = fmt.Sprintf("https://%s.api.blizzard.com", region)
 		c.dynamicNamespace = fmt.Sprintf("dynamic-%s", region)
 		c.dynamicClassicNamespace = fmt.Sprintf("dynamic-classic-%s", region)
@@ -187,7 +187,7 @@ func (c *Client) SetRegionParameters(region Region, locale Locale) error {
 		c.staticClassicNamespace = fmt.Sprintf("static-classic-%s", region)
 	}
 
-	c.clntCredCfg.TokenURL = c.oauthHost + "/oauth/token"
+	c.clntCredCfg.TokenURL = c.oauthHost + "/token"
 	c.httpClient = c.clntCredCfg.Client(
 		context.WithValue(context.TODO(), oauth2.HTTPClient, c.cfg.HTTPClient),
 	)

--- a/oauth.go
+++ b/oauth.go
@@ -33,8 +33,8 @@ func (c *Client) AuthorizeConfig(redirectURI string, profiles ...oauth.Profile) 
 		Scopes:       scopes,
 		RedirectURL:  redirectURI,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  c.oauthHost + "/oauth/authorize",
-			TokenURL: c.oauthHost + "/oauth/token",
+			AuthURL:  c.oauthHost + "/authorize",
+			TokenURL: c.oauthHost + "/token",
 		},
 	}
 
@@ -50,7 +50,7 @@ func (c *Client) AccessTokenRequest(ctx context.Context) error {
 		err  error
 	)
 
-	req, err = http.NewRequestWithContext(ctx, "POST", c.oauthHost+"/oauth/token", strings.NewReader("grant_type=client_credentials"))
+	req, err = http.NewRequestWithContext(ctx, "POST", c.clntCredCfg.TokenURL, strings.NewReader("grant_type=client_credentials"))
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (c *Client) UserInfoHeader(token *oauth2.Token) (*oauth.UserInfo, []byte, e
 		err    error
 	)
 
-	req, err = http.NewRequest("GET", c.oauthHost+"/oauth/userinfo", nil)
+	req, err = http.NewRequest("GET", c.oauthHost+"/userinfo", nil)
 	if err != nil {
 		return &dat, b, err
 	}
@@ -128,7 +128,7 @@ func (c *Client) TokenValidation(ctx context.Context, token *oauth2.Token) (*oau
 		err error
 	)
 
-	req, err = http.NewRequestWithContext(ctx, "GET", c.oauthHost+fmt.Sprintf("/oauth/check_token?token=%s", token.AccessToken), nil)
+	req, err = http.NewRequestWithContext(ctx, "GET", c.oauthHost+fmt.Sprintf("/v2/check_token?token=%s", token.AccessToken), nil)
 	if err != nil {
 		return &dat, b, err
 	}


### PR DESCRIPTION
Blizzard seem to have changed their OAuth endpoints. The old ones are still working (except for taiwan. Trying to request a token results in a 403).

I've updated the endpoints to match those provided in the documentation: https://develop.battle.net/documentation/guides/using-oauth (see OAUth URIs). And for some of the corrected paths I've used the openid-configuration: https://oauth.battle.net/.well-known/openid-configuration as source.

The only thing still not working is the china oauth endpoint. The old endpoint resolves to an IP that is not reachable and the new endpoint does not have any A-Record for that name. I guess that this is related to the current situation between blizzard and china.