### PR TITLE
Adding Item Sets to Character Equipment Struct

### DIFF
--- a/wowp/characterEquipment.go
+++ b/wowp/characterEquipment.go
@@ -280,6 +280,25 @@ type CharacterEquipmentSummary struct {
 				DisplayString string `json:"display_string"`
 			} `json:"skill"`
 		} `json:"requirements,omitempty"`
+		Set struct {
+			ItemSet struct {
+				Key struct {
+					Href string `json:"href"`
+				}
+				Name string `json:"name"`
+				ID   int    `json:"id"`
+			}
+			Items []struct {
+				Item struct {
+					Key struct {
+						Href string `json:"href"`
+					}
+					Name string `json:"name"`
+					ID   int    `json:"id"`
+				}
+				IsEquipped bool
+			}
+		}
 		Weapon struct {
 			Damage struct {
 				MinValue      int    `json:"min_value"`

--- a/wowp/characterEquipment.go
+++ b/wowp/characterEquipment.go
@@ -298,6 +298,12 @@ type CharacterEquipmentSummary struct {
 				}
 				IsEquipped bool
 			}
+			Effects []struct {
+				DisplayString string
+				RequiredCount int
+				IsActive      bool
+			}
+			DisplayString string
 		}
 		Weapon struct {
 			Damage struct {

--- a/wowp/characterEquipment.go
+++ b/wowp/characterEquipment.go
@@ -284,26 +284,26 @@ type CharacterEquipmentSummary struct {
 			ItemSet struct {
 				Key struct {
 					Href string `json:"href"`
-				}
+				} `json:"key"`
 				Name string `json:"name"`
 				ID   int    `json:"id"`
-			}
+			} `json:"item_set"`
 			Items []struct {
 				Item struct {
 					Key struct {
 						Href string `json:"href"`
-					}
+					} `json:"key"`
 					Name string `json:"name"`
 					ID   int    `json:"id"`
-				}
-				IsEquipped bool
-			}
+				} `json:"item"`
+				IsEquipped bool `json:"is_equipped"`
+			} `json:"items"`
 			Effects []struct {
-				DisplayString string
-				RequiredCount int
-				IsActive      bool
-			}
-			DisplayString string
+				DisplayString string `json:"display_string"`
+				RequiredCount int    `json:"required_count"`
+				IsActive      bool   `json:"is_active"`
+			} `json:"effects"`
+			DisplayString string `json:"display_string"`
 		}
 		Weapon struct {
 			Damage struct {


### PR DESCRIPTION
First off, thank you for doing all of this work!  It has been great to not have to write it all myself.

For the character profile equipment endpoint, the `set` is missing.

**Example:**

```json
{
  "set": {
    "item_set": {
      "key": {
        "href": "https://us.api.blizzard.com/data/wow/item-set/1564?namespace=static-10.2.6_53703-us"
      },
      "name": "Zealous Pyreknight's Ardor",
      "id": 1564
    },
    "items": [
      {
        "item": {
          "key": {
            "href": "https://us.api.blizzard.com/data/wow/item/207189?namespace=static-10.2.6_53703-us"
          },
          "name": "Zealous Pyreknight's Ailettes",
          "id": 207189
        },
        "is_equipped": true
      },
      {
        "item": {
          "key": {
            "href": "https://us.api.blizzard.com/data/wow/item/207190?namespace=static-10.2.6_53703-us"
          },
          "name": "Zealous Pyreknight's Cuisses",
          "id": 207190
        }
      },
      {
        "item": {
          "key": {
            "href": "https://us.api.blizzard.com/data/wow/item/207191?namespace=static-10.2.6_53703-us"
          },
          "name": "Zealous Pyreknight's Barbute",
          "id": 207191
        },
        "is_equipped": true
      },
      {
        "item": {
          "key": {
            "href": "https://us.api.blizzard.com/data/wow/item/207192?namespace=static-10.2.6_53703-us"
          },
          "name": "Zealous Pyreknight's Jeweled Gauntlets",
          "id": 207192
        },
        "is_equipped": true
      },
      {
        "item": {
          "key": {
            "href": "https://us.api.blizzard.com/data/wow/item/207194?namespace=static-10.2.6_53703-us"
          },
          "name": "Zealous Pyreknight's Warplate",
          "id": 207194
        },
        "is_equipped": true
      }
    ],
    "effects": [
      {
        "display_string": "Set: Expurgation lasts an additional 3 sec and deals 30% increased damage. Casting Judgment or Divine Toll on a target with Expurgation causes Wrathful Sanction, damaging the target for 25,680 Holy damage and resonating 12,960 Holy damage to up to 4 nearby enemies.",
        "required_count": 2,
        "is_active": true
      },
      {
        "display_string": "Set: Wrathful Sanction grants you Echoes of Wrath, causing your next Templar's Verdict or Divine Storm to deal damage a second time at 25% effectiveness. This effect does not consume Judgment.",
        "required_count": 4,
        "is_active": true
      }
    ],
    "display_string": "Zealous Pyreknight's Ardor (4/5)"
  }
}
```

I have gone ahead and added it to the `Struct` in the proper hierarchical spot.