### PR TITLE
Creature Display ID -- For Retail

### DIFF
--- a/wowgd/creature.go
+++ b/wowgd/creature.go
@@ -87,6 +87,7 @@ type Creature struct {
 		Key struct {
 			Href string `json:"href"`
 		} `json:"key"`
+		ID int `json:"id"`
 	} `json:"creature_displays"`
 	IsTameable bool `json:"is_tameable"`
 }


### PR DESCRIPTION
I updated the Classic version of the Creature (which is still valid), but missed the one for Retail.

Anyways, this adds in the ID for Retail.