### PR TITLE
Add Parent Category for Achievement Category

### DIFF
--- a/wowgd/achievement.go
+++ b/wowgd/achievement.go
@@ -53,6 +53,13 @@ type AchievementCategory struct {
 		Name string `json:"name"`
 		ID   int    `json:"id"`
 	} `json:"subcategories"`
+	ParentCategory struct {
+		Key struct {
+			Href string `json:"href"`
+		} `json:"key"`
+		Name string `json:"name"`
+		ID   int    `json:"id"`
+	}
 	IsGuildCategory     bool `json:"is_guild_category"`
 	AggregatesByFaction struct {
 		Alliance struct {

--- a/wowgd/achievement.go
+++ b/wowgd/achievement.go
@@ -59,7 +59,7 @@ type AchievementCategory struct {
 		} `json:"key"`
 		Name string `json:"name"`
 		ID   int    `json:"id"`
-	} `json:"parentCategory"`
+	} `json:"parent_category"`
 	IsGuildCategory     bool `json:"is_guild_category"`
 	AggregatesByFaction struct {
 		Alliance struct {

--- a/wowgd/achievement.go
+++ b/wowgd/achievement.go
@@ -59,7 +59,7 @@ type AchievementCategory struct {
 		} `json:"key"`
 		Name string `json:"name"`
 		ID   int    `json:"id"`
-	}
+	} `json:"parentCategory"`
 	IsGuildCategory     bool `json:"is_guild_category"`
 	AggregatesByFaction struct {
 		Alliance struct {


### PR DESCRIPTION
Adding support for missing the Parent Category for Achievement Categories that have a parent.

```
"parent_category": {
        "key": {
            "href": "https://us.api.blizzard.com/data/wow/achievement-category/95?namespace=static-10.2.6_53703-us"
        },
        "name": "Player vs. Player",
        "id": 95
    },
```